### PR TITLE
OI-26: Removed comment title and permalink from the template. Added t…

### DIFF
--- a/config/install/core.entity_view_display.comment.comment.default.yml
+++ b/config/install/core.entity_view_display.comment.comment.default.yml
@@ -6,8 +6,87 @@ dependencies:
     - field.field.comment.comment.comment_body
     - field.field.comment.comment.field_voting_comment
   module:
+    - layout_builder
+    - layout_discovery
     - text
     - votingapi_widgets
+third_party_settings:
+  layout_builder:
+    allow_custom: false
+    enabled: true
+    sections:
+      -
+        layout_id: layout_onecol
+        layout_settings:
+          label: ''
+        components:
+          5e5f6f5e-1a41-43b9-8d91-eac5268073c5:
+            uuid: 5e5f6f5e-1a41-43b9-8d91-eac5268073c5
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:comment:comment:comment_body'
+              formatter:
+                label: hidden
+                type: text_default
+                settings: {  }
+                third_party_settings: {  }
+            additional: {  }
+            weight: 1
+          f0946b35-1cb9-42af-baac-10df8b49f6fc:
+            uuid: f0946b35-1cb9-42af-baac-10df8b49f6fc
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'extra_field_block:comment:comment:links'
+            additional: {  }
+            weight: 2
+          0649b091-fd23-41cc-ba66-bc4c70aa7076:
+            uuid: 0649b091-fd23-41cc-ba66-bc4c70aa7076
+            region: content
+            configuration:
+              label_display: '0'
+              context_mapping:
+                entity: layout_builder.entity
+              id: 'field_block:comment:comment:field_voting_comment'
+              formatter:
+                label: hidden
+                settings:
+                  style: default
+                  show_results: '1'
+                  readonly: 0
+                  values: {  }
+                  show_own_vote: false
+                third_party_settings: {  }
+                type: voting_api_formatter
+            additional: {  }
+            weight: 3
+          68436313-ad30-4361-8454-b9448b100777:
+            uuid: 68436313-ad30-4361-8454-b9448b100777
+            region: content
+            configuration:
+              id: 'field_block:comment:comment:created'
+              label: Created
+              provider: layout_builder
+              label_display: '0'
+              formatter:
+                label: hidden
+                type: timestamp_ago
+                settings:
+                  future_format: '@interval hence'
+                  past_format: '@interval ago'
+                  granularity: 2
+                third_party_settings: {  }
+              context_mapping:
+                entity: layout_builder.entity
+                view_mode: view_mode
+            additional: {  }
+            weight: 0
+        third_party_settings: {  }
 id: comment.comment.default
 targetEntityType: comment
 bundle: comment
@@ -28,6 +107,7 @@ content:
       show_results: '1'
       readonly: 0
       values: {  }
+      show_own_vote: false
     third_party_settings: {  }
     type: voting_api_formatter
     region: content

--- a/idea.info.yml
+++ b/idea.info.yml
@@ -103,6 +103,7 @@ dependencies:
   - openideal_idea:openideal_idea
   - openideal_user:openideal_user
   - openideal_slideshow:openideal_slideshow
+  - openideal_comment:openideal_comment
 
 themes:
   - adminimal_theme

--- a/modules/openideal_comment/openideal_comment.info.yml
+++ b/modules/openideal_comment/openideal_comment.info.yml
@@ -1,0 +1,6 @@
+name: 'OpenideaL Comment'
+type: module
+description: 'Provides main features/functionality for OpenideaL comment module.'
+package: OpenideaL
+core: 8.x
+core_version_requirement: ^8 || ^9

--- a/modules/openideal_comment/openideal_comment.services.yml
+++ b/modules/openideal_comment/openideal_comment.services.yml
@@ -1,0 +1,6 @@
+services:
+  openideal_comment.subscriber:
+    class: Drupal\openideal_comment\EventSubscriber\OpenidealCommentEventSubscriber
+    arguments: []
+    tags:
+      - { name: event_subscriber }

--- a/modules/openideal_comment/src/EventSubscriber/OpenidealCommentEventSubscriber.php
+++ b/modules/openideal_comment/src/EventSubscriber/OpenidealCommentEventSubscriber.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\openideal_comment\EventSubscriber;
+
+use Drupal\Core\Messenger\MessengerTrait;
+use Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent;
+use Drupal\layout_builder\LayoutBuilderEvents;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Class OpenidealCommentEventSubscriber.
+ */
+class OpenidealCommentEventSubscriber implements EventSubscriberInterface {
+
+  use MessengerTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function getSubscribedEvents() {
+    $events[LayoutBuilderEvents::SECTION_COMPONENT_BUILD_RENDER_ARRAY] = ['onComponentBuild'];
+    return $events;
+  }
+
+  /**
+   * Change the way field created is displayed in layout builder.
+   *
+   * @param \Drupal\layout_builder\Event\SectionComponentBuildRenderArrayEvent $event
+   *   Event.
+   */
+  public function onComponentBuild(SectionComponentBuildRenderArrayEvent $event) {
+    if ($event->getPlugin()->getPLuginId() == 'field_block:comment:comment:created') {
+      $build = $event->getBuild();
+      $content = $build['content'];
+      $comment = $content['#object'];
+      // Change the default permalink of comment title.
+      $commented_entity = $comment->getCommentedEntity();
+      $uri = $commented_entity->toUrl();
+
+      // Set attributes for permalink.
+      $attributes = $uri->getOption('attributes') ?: [];
+      $attributes += ['class' => ['permalink'], 'rel' => 'bookmark'];
+      $uri->setOptions([
+        'attributes' => $attributes,
+        'fragment' => 'comment-' . $comment->id(),
+      ]);
+
+      $build['content'][0] = [
+        '#type' => 'link',
+        '#title' => $content[0]['#markup'],
+        '#url' => $uri,
+      ];
+      $event->setBuild($build);
+    }
+  }
+
+}

--- a/themes/openideal_theme/openideal_theme.theme
+++ b/themes/openideal_theme/openideal_theme.theme
@@ -6,30 +6,3 @@
  *
  * Place your custom PHP code in this file.
  */
-
-use Drupal\Core\Link;
-
-/**
- * Implements hook_preprocess_HOOK().
- */
-function openideal_theme_preprocess_comment(&$variables) {
-  // Change the default permalink of comment title.
-  $comment = $variables['elements']['#comment'];
-  $owner = $comment->getOwner();
-  $commented_entity = $comment->getCommentedEntity();
-  $uri = $commented_entity->toUrl();
-
-  // Set attributes for permalink.
-  $attributes = $uri->getOption('attributes') ?: [];
-  $attributes += ['class' => ['permalink'], 'rel' => 'bookmark'];
-  $uri->setOptions([
-    'attributes' => $attributes,
-    'fragment' => 'comment-' . $comment->id(),
-  ]);
-
-  unset($variables['permalink']);
-
-  // Because of user 1 can be without first and last name, just take its name.
-  $owner_name = $owner->realname ?: $owner->name->value;
-  $variables['title'] = Link::fromTextAndUrl($owner_name, $uri)->toString();
-}

--- a/themes/openideal_theme/templates/comment.html.twig
+++ b/themes/openideal_theme/templates/comment.html.twig
@@ -1,0 +1,97 @@
+{#
+/**
+ * @file
+ * Default theme implementation for comments.
+ *
+ * Available variables:
+ * - author: Comment author. Can be a link or plain text.
+ * - content: The content-related items for the comment display. Use
+ *   {{ content }} to print them all, or print a subset such as
+ *   {{ content.field_example }}. Use the following code to temporarily suppress
+ *   the printing of a given child element:
+ *   @code
+ *   {{ content|without('field_example') }}
+ *   @endcode
+ * - created: Formatted date and time for when the comment was created.
+ *   Preprocess functions can reformat it by calling DateFormatter::format()
+ *   with the desired parameters on the 'comment.created' variable.
+ * - changed: Formatted date and time for when the comment was last changed.
+ *   Preprocess functions can reformat it by calling DateFormatter::format()
+ *   with the desired parameters on the 'comment.changed' variable.
+ * - permalink: Comment permalink.
+ * - submitted: Submission information created from author and created
+ *   during template_preprocess_comment().
+ * - user_picture: The comment author's profile picture.
+ * - status: Comment status. Possible values are:
+ *   unpublished, published, or preview.
+ * - title: Comment title, linked to the comment.
+ * - attributes: HTML attributes for the containing element.
+ *   The attributes.class may contain one or more of the following classes:
+ *   - comment: The current template type; for instance, 'theming hook'.
+ *   - by-anonymous: Comment by an unregistered user.
+ *   - by-{entity-type}-author: Comment by the author of the parent entity,
+ *     eg. by-node-author.
+ *   - preview: When previewing a new or edited comment.
+ *   The following applies only to viewers who are registered users:
+ *   - unpublished: An unpublished comment visible only to administrators.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ * - content_attributes: List of classes for the styling of the comment content.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - threaded: A flag indicating whether the comments are threaded or not.
+ *
+ * These variables are provided to give context about the parent comment (if
+ * any):
+ * - parent_comment: Full parent comment entity (if any).
+ * - parent_author: Equivalent to author for the parent comment.
+ * - parent_created: Equivalent to created for the parent comment.
+ * - parent_changed: Equivalent to changed for the parent comment.
+ * - parent_title: Equivalent to title for the parent comment.
+ * - parent_permalink: Equivalent to permalink for the parent comment.
+ * - parent: A text string of parent comment submission information created from
+ *   'parent_author' and 'parent_created' during template_preprocess_comment().
+ *   This information is presented to help screen readers follow lengthy
+ *   discussion threads. You can hide this from sighted users using the class
+ *   visually-hidden.
+ *
+ * These two variables are provided for context:
+ * - comment: Full comment object.
+ * - entity: Entity the comments are attached to.
+ *
+ * @see template_preprocess_comment()
+ *
+ * @ingroup themeable
+ */
+#}
+
+<article{{ attributes.addClass('js-comment') }}>
+
+    {#
+      Hide the "new" indicator by default, let a piece of JavaScript ask the
+      server which comments are new for the user. Rendering the final "new"
+      indicator here would break the render cache.
+    #}
+  <mark class="hidden" data-comment-timestamp="{{ new_indicator_timestamp }}"></mark>
+
+  <footer>
+    {{ user_picture }}
+
+      {#
+        Indicate the semantic relationship between parent and child comments for
+        accessibility. The list is difficult to navigate in a screen reader
+        without this information.
+      #}
+
+    {% if parent %}
+      <p class="visually-hidden">{{ parent }}</p>
+    {% endif %}
+
+  </footer>
+
+  <div{{ content_attributes }}>
+    {{ content }}
+  </div>
+</article>


### PR DESCRIPTION
…he field_created into the comment's display via layout_builder. Create openideal_comment module, and implemented there EventSubscriber to change the created field display behaviour to be a permalink.